### PR TITLE
Feat: Compute module to house computational resources

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -32,13 +32,24 @@ module "security" {
   source = "./modules/security"
 
   vpc_id                           = module.networking.vpc_id
-  bastion_host_key_path            = var.bastion_host_key_path
+  host_key_path                    = var.host_key_path
   bastion_host_allowed_cidr_blocks = var.bastion_host_allowed_cidr_blocks
   allow_bastion_host_http_traffic  = var.allow_bastion_host_http_traffic
   allow_bastion_host_https_traffic = var.allow_bastion_host_https_traffic
 
+  base_name = local.base_name
+  tags      = local.default_tags
+}
 
-  private_instance_key_path = var.private_instance_key_path
-  base_name                 = local.base_name
-  tags                      = local.default_tags
+module "compute" {
+  source = "./modules/compute"
+
+  bastion_instance_type     = var.bastion_instance_type
+  public_subnet_ids         = module.networking.public_subnets_ids
+  bastion_security_group_id = module.security.bastion_security_group_id
+  key_pair                  = module.security.key_pair
+  bastion_user_data_script  = "${path.root}/../${var.bastion_data_script_path}"
+
+  base_name = local.base_name
+  tags      = local.default_tags
 }

--- a/infra/modules/compute/main.tf
+++ b/infra/modules/compute/main.tf
@@ -1,0 +1,59 @@
+
+# Get the latest ubuntu AMI
+data "aws_ami" "latest_ubuntu" {
+  owners      = ["099720109477"] # Canonical's AWS Account ID for Ubuntu AMIs
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+# Random subnet id for bastion host
+resource "random_shuffle" "bastion" {
+  result_count = 1
+  input        = var.public_subnet_ids
+  keepers = {
+    ami_id = var.bastion_instance_type
+  }
+}
+
+# Bastion host
+resource "aws_instance" "bastion" {
+  ami                         = data.aws_ami.latest_ubuntu.id
+  instance_type               = var.bastion_instance_type
+  subnet_id                   = random_shuffle.bastion.result[0]
+  vpc_security_group_ids      = [var.bastion_security_group_id]
+  associate_public_ip_address = true
+  key_name                    = var.key_pair
+
+  root_block_device {
+    volume_size           = 10
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+    tags = merge(var.tags, {
+      Name = "${var.base_name}-bastion-volume"
+    })
+  }
+
+  user_data = var.bastion_user_data_script != "" ? templatefile(var.bastion_user_data_script, {
+    hostname = "${var.base_name}-bastion"
+  }) : null
+
+  tags = merge(var.tags, {
+    Name = "${var.base_name}-bastion"
+  })
+
+}

--- a/infra/modules/compute/outputs.tf
+++ b/infra/modules/compute/outputs.tf
@@ -1,0 +1,9 @@
+output "bastion_public_ip" {
+  description = "IPv4 address of the bastion host"
+  value       = aws_instance.bastion.public_ip
+}
+
+output "bastion_public_dns" {
+  description = "Public dns of the bastion host"
+  value       = aws_instance.bastion.public_dns
+}

--- a/infra/modules/compute/variables.tf
+++ b/infra/modules/compute/variables.tf
@@ -1,0 +1,46 @@
+variable "bastion_instance_type" {
+  description = "The instance type of the bastion host"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "The IDs of public subnets"
+  type        = list(string)
+  validation {
+    condition     = length(var.public_subnet_ids) > 0
+    error_message = "At least one public subnet ID must be provided"
+  }
+}
+
+variable "bastion_security_group_id" {
+  description = "Bastion host security group"
+  type        = string
+}
+
+variable "key_pair" {
+  description = "Bastion key-pair"
+  type        = string
+}
+
+
+variable "bastion_user_data_script" {
+  description = "Path to the user data script"
+  type        = string
+  default     = ""
+  validation {
+    condition     = fileexists(var.bastion_user_data_script) || var.bastion_user_data_script == ""
+    error_message = "Bastion user data script file does not exists in the specified location."
+  }
+}
+
+
+
+variable "tags" {
+  description = "A map of tags to assign to resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "base_name" {
+  description = "The basename for all resources."
+}

--- a/infra/modules/compute/versions.tf
+++ b/infra/modules/compute/versions.tf
@@ -3,5 +3,8 @@ terraform {
     aws = {
       source = "hashicorp/aws"
     }
+    random = {
+      source = "hashicorp/random"
+    }
   }
 }

--- a/infra/modules/security/main.tf
+++ b/infra/modules/security/main.tf
@@ -5,13 +5,13 @@ data "aws_ec2_managed_prefix_list" "cloudfront" {
 }
 
 # --- Bastion host ----
-# Bastion host key pair
-resource "aws_key_pair" "bastion" {
-  key_name   = "${var.base_name}-bastion-key"
-  public_key = file(var.bastion_host_key_path)
+# Key pair
+resource "aws_key_pair" "key" {
+  key_name   = "${var.base_name}-key-pair"
+  public_key = file(var.host_key_path)
 
   tags = merge(var.tags, {
-    Name = "${var.base_name}-bastion-key"
+    Name = "${var.base_name}-key-pair"
   })
 
 }
@@ -76,15 +76,6 @@ resource "aws_security_group" "bastion" {
 }
 
 # ---- Private instances ---
-# Private instance key pair
-resource "aws_key_pair" "private" {
-  key_name   = "${var.base_name}-private-key"
-  public_key = file(var.private_instance_key_path)
-
-  tags = merge(var.tags, {
-    Name = "${var.base_name}-private-key"
-  })
-}
 
 # Private instance security group
 resource "aws_security_group" "private" {
@@ -112,7 +103,7 @@ resource "aws_security_group" "private" {
     description     = "HTTP from ALB"
     from_port       = 80
     to_port         = 80
-    protocol = "tcp"
+    protocol        = "tcp"
     security_groups = [aws_security_group.alb.id]
   }
 
@@ -149,10 +140,10 @@ resource "aws_security_group" "alb" {
   }
 
   egress {
-    description     = "All traffic to target groups"
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
+    description = "All traffic to target groups"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 

--- a/infra/modules/security/outputs.tf
+++ b/infra/modules/security/outputs.tf
@@ -3,10 +3,16 @@ output "bastion_security_group_id" {
   value       = aws_security_group.bastion.id
 }
 
+output "key_pair" {
+  description = "Bastion host key name"
+  value       = aws_key_pair.key.key_name
+}
+
 output "private_security_group_id" {
   description = "Private instance security group ID"
   value       = aws_security_group.private.id
 }
+
 
 output "alb_security_group_id" {
   description = "ALB security group ID"

--- a/infra/modules/security/variables.tf
+++ b/infra/modules/security/variables.tf
@@ -9,7 +9,7 @@ variable "vpc_id" {
 
 }
 
-variable "bastion_host_key_path" {
+variable "host_key_path" {
   description = "Path to public key for public instances"
   type        = string
 }
@@ -31,10 +31,6 @@ variable "allow_bastion_host_https_traffic" {
   default     = false
 }
 
-variable "private_instance_key_path" {
-  description = "Path to private key for private instances"
-  type        = string
-}
 
 variable "tags" {
   description = "A map of tags to assign to resources"

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,3 +1,4 @@
+# --- Root module ----
 output "bucket_name" {
   description = "Name of the S3 bucket for Terraform state"
   value       = aws_s3_bucket.terraform_state.id
@@ -11,4 +12,18 @@ output "bucket_arn" {
 output "iam_policy_arn" {
   description = "ARN of the IAM policy for Terraform state access"
   value       = aws_iam_policy.terraform_state_policy.arn
+}
+
+# --- Networking module ----
+
+# --- Security module ---
+
+# --- Compute module ---
+output "bastion_commands" {
+  description = "Commands to connect to bastion host"
+  value = {
+    public_ip   = module.compute.bastion_public_ip
+    public_dns  = module.compute.bastion_public_dns
+    ssh_command = "ssh ubuntu@${module.compute.bastion_public_ip}"
+  }
 }

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -9,7 +9,7 @@ terraform {
 
     random = {
       source  = "hashicorp/random"
-      version = "3.7.2"
+      version = "~> 3.7.0"
     }
   }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,4 +1,4 @@
-# ---- Root Module
+# ---- Root Module ---
 variable "region" {
   description = "The region to create resources"
   type        = string
@@ -31,7 +31,7 @@ variable "state_version_retention_days" {
   default     = 90
 }
 
-# --- Networking module
+# --- Networking module ---
 
 variable "vpc_cidr" {
   description = "CIDR block for the VPC"
@@ -78,7 +78,7 @@ variable "tags" {
 }
 
 # ---- Security Module ---
-variable "bastion_host_key_path" {
+variable "host_key_path" {
   description = "Path to public key for public instances"
   type        = string
   default     = "~/.ssh/id_rsa.pub"
@@ -102,8 +102,25 @@ variable "allow_bastion_host_https_traffic" {
   default     = false
 }
 
-variable "private_instance_key_path" {
-  description = "Path to public key for private instances"
+# ---- Compute ----
+variable "bastion_instance_type" {
+  description = "The instance type of the bastion host"
   type        = string
-  default     = "~/.ssh/id_rsa.pub"
+  default     = "t2.micro"
+}
+
+variable "bastion_data_script_path" {
+  description = "Bastion data script path in relative to root dir"
+}
+
+variable "bastion_connection_key_path" {
+  description = "Bastion SSH private key path"
+  type        = string
+  default     = "~/.ssh/id_rsa"
+}
+
+variable "private_connection_key_path" {
+  description = "Private instance SSH private key path"
+  type        = string
+  default     = "~/.ssh/id_rsa"
 }

--- a/scripts/bastion_data.sh
+++ b/scripts/bastion_data.sh
@@ -1,0 +1,54 @@
+#! /bin/bash
+
+sudo apt update && sudo apt dist-upgrade -y
+
+sudo hostnamectl set-hostname "${hostname}"
+echo "127.0.1.1 ${hostname}" | sudo tee -a /etc/hosts
+
+sudo apt install -y nginx unzip
+sudp systemctl enable nginx
+
+# Get the instance ID
+export TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+
+cat <<-EOF | sudo tee /var/www/html/index.html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Welcome to Nginx</title>
+    <style>
+        body {font-family: Arial, sans-serif;background-color: #f4f4f9;color: #333;margin: 0;display: flex;justify-content: center;align-items: center;height: 100vh;text-align: center;}
+        .container {padding: 20px;border: 1px solid #ddd;border-radius: 8px;box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);background-color: #fff;}
+        h1 {color: #555;}
+        p {font-size: 1.2em;}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Bastion host: ${hostname} up and running!</h1>
+        <h3>Instance ID: $INSTANCE_ID.</h3>
+    </div>
+</body>
+</html>
+EOF
+sudo systemctl restart nginx
+
+# Secure server
+sudo sed -i 's/#PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
+sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
+systemctl restart sshd
+
+
+# Simple motd
+cat <<-EOF | sudo tee /etc/motd
+===============================================
+  ${hostname}
+  $(date)
+===============================================
+EOF
+
+# Log completion
+sudo sh -c 'echo "$(date): User data script completed successfully" >> /var/log/user-data.log'

--- a/scripts/terraform.sh
+++ b/scripts/terraform.sh
@@ -13,7 +13,7 @@ readonly SCRIPT_NAME="terraform-automation"
 # Folders
 readonly BASE_DIR="$PROJECT_ROOT/infra"         # Terraform base directory
 readonly MODULES_BASE_DIR="${BASE_DIR}/modules" # The folder to house the modules
-readonly MODULES_DIRS=("networking" "security")
+readonly MODULES_DIRS=("networking" "security" "compute")
 
 # files
 readonly BASE_DIR_FILES=("main.tf" "variables.tf" "outputs.tf" "providers.tf" "terraform.tfvars" "backend.tf" ".terraformignore" "README.md")


### PR DESCRIPTION
1. ## Compute Module
    - 1. Provision as Bastion/jump server in one public subnet to help in connecting to private instances via ssh.
2. ## Security Module
     - 1. Only create one key pair for all ec2 instances for SSH agent, ensuring no ssh keys are copied over to bastion server. This ensure maximum security for resources deployed in private subnets
 3. ## Scripts
     - Add a bastion script file to help in initial bastion host configurations.